### PR TITLE
Set registrant field optional in domain info response

### DIFF
--- a/rpp/model/epp/common_converter.py
+++ b/rpp/model/epp/common_converter.py
@@ -19,7 +19,7 @@ def login(
     login_options = CredsOptionsType(version=version, lang=lang)
 
     login_svc = LoginSvcType(
-        obj_uri=obj_uri, svc_extension=ExtUritype(ext_uri=ext_uri)
+        obj_uri=obj_uri, svc_extension=ExtUritype(ext_uri=ext_uri) if ext_uri else None
     )
 
     login = LoginType(

--- a/rpp/model/epp/common_converter.py
+++ b/rpp/model/epp/common_converter.py
@@ -19,7 +19,7 @@ def login(
     login_options = CredsOptionsType(version=version, lang=lang)
 
     login_svc = LoginSvcType(
-        obj_uri=obj_uri, svc_extension=ExtUritype(ext_uri=ext_uri) if ext_uri else None
+        obj_uri=obj_uri, svc_extension=ExtUritype(ext_uri=ext_uri)
     )
 
     login = LoginType(

--- a/rpp/model/rpp/domain.py
+++ b/rpp/model/rpp/domain.py
@@ -73,7 +73,7 @@ class DomainCheckRequest(BaseRequestModel):
 
 class DomainInfoResponse(BaseModel):
     name: str
-    registrant: str
+    registrant: Optional[str] = None
     roid: str
     status: Optional[List[str]] = None
     dnssec: Optional[DsOrKeyType] = None


### PR DESCRIPTION
Nominet's implementation of EPP doesn't provide this field for non-sponsoring registrars